### PR TITLE
Removing siteConfig from map provided function

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Gradle Project settings
 projectName = favicon
-version = 2.0.3
+version = 2.0.3-beta
 
 # XP App values
 appDisplayName = Favicon

--- a/src/main/resources/site/processors/favicon.js
+++ b/src/main/resources/site/processors/favicon.js
@@ -45,12 +45,8 @@ function createMetaLink(size, siteConfig, rel, type) {
 
 function iconLink(siteConfig) {
   return [createMetaLink(64, siteConfig, 'shortcut icon', 'png')]
-    .concat(sizes.map(function (size, siteConfig) {
-      return createMetaLink(size, siteConfig, 'apple-touch-icon');
-    }))
-    .concat(altSizes.map(function (size, siteConfig) {
-      return createMetaLink(size, siteConfig, 'icon', 'png');
-    }))
+    .concat(sizes.map(size => createMetaLink(size, siteConfig, 'apple-touch-icon')))
+    .concat(altSizes.map(size => createMetaLink(size, siteConfig, 'icon', 'png')))
     .join('\n');
 }
 


### PR DESCRIPTION
The siteConfig input may be considered as the index param for the map function, causing siteConfig.favicon in createMetaLink to be undefined. It seems the default behavior for portalLib.imageUrl, if the media content ID is undefined, is to fetch the current content's ID, which usually isn't a media content, therefore throwing an exception.
The changes (L49 and L53):
![image](https://github.com/user-attachments/assets/6bed22ab-ef31-44bb-94d4-5bc2d71e228d)
Generated this log:
![logs](https://github.com/user-attachments/assets/cf92d65a-6003-40ea-b6fa-a9d14d5324b5)